### PR TITLE
bind client socket to address. used for listener

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ slog = "^2.2"
 slog-stdlog = "^3.0"
 capnp="^0.9"
 capnp-futures="^0.9"
+net2 = "^0.2"
 
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ pub fn start_raft_tcp<RL, RM, L, N, C>(
     protocol.set_logger(logger.clone());
 
     // create connection watcher
+    let bind_addr = (listen.ip().to_string() + ":0").parse::<SocketAddr>().unwrap();
     let watcher = TcpWatch::new(
         id,
         nodes.clone(),
@@ -143,6 +144,7 @@ pub fn start_raft_tcp<RL, RM, L, N, C>(
         handshake.clone(),
         logger.clone(),
         solver.clone(),
+        bind_addr,
     );
 
     spawn(protocol.map_err(
@@ -200,8 +202,8 @@ mod tests {
     fn temp_test() {
         let mut nodes: HashMap<ServerId, SocketAddr> = HashMap::new();
         nodes.insert(1.into(), "127.0.0.1:9991".parse().unwrap());
-        nodes.insert(2.into(), "127.0.0.1:9992".parse().unwrap());
-        nodes.insert(3.into(), "127.0.0.1:9993".parse().unwrap());
+        nodes.insert(2.into(), "127.0.0.2:9992".parse().unwrap());
+        nodes.insert(3.into(), "127.0.0.3:9993".parse().unwrap());
         //nodes.insert(4.into(), "127.0.0.1:9994".parse().unwrap());
 
         let mut threads = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ extern crate slog_stdlog;
 extern crate tokio;
 extern crate tokio_codec;
 extern crate tokio_io;
+extern crate net2;
 
 use std::collections::HashMap;
 use std::net::SocketAddr;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -484,6 +484,7 @@ where
             }
         }
         if state != self.handler.state {
+            //trace!(logger, "state {} -> {}", raft_consensus_state_fmt(&self.handler.state), raft_consensus_state_fmt(&state));
             self.notifier
                 .state_changed(state, self.handler.state.clone());
         }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -136,8 +136,8 @@ where
                     }
                     Either::B(id) => (id, &addrs[&id]),
                 };
-
                 let bind_addr = (addr.ip().to_string() + ":0").parse::<SocketAddr>().unwrap();
+                debug!(logger.clone(), "bind raft client to {}", bind_addr.ip().to_string());
                 let client = TcpClient::new(*addr, Duration::from_millis(300), bind_addr);
 
                 let conns = conns.clone();

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -55,6 +55,7 @@ where
     handshake: H,
     logger: Logger,
     solver: C,
+    bind_addr: SocketAddr,
 }
 
 impl<T, H, C> TcpWatch<T, H, C>
@@ -72,6 +73,7 @@ where
         handshake: H,
         logger: Logger,
         solver: C,
+        bind_addr: SocketAddr,
     ) -> Self {
         Self {
             id,
@@ -83,6 +85,7 @@ where
             handshake,
             logger,
             solver,
+            bind_addr,
         }
     }
 }
@@ -109,6 +112,7 @@ where
             transport,
             logger,
             solver,
+            bind_addr,
         } = self;
 
         let conns = conns.clone();
@@ -136,7 +140,6 @@ where
                     }
                     Either::B(id) => (id, &addrs[&id]),
                 };
-                let bind_addr = (addr.ip().to_string() + ":0").parse::<SocketAddr>().unwrap();
                 let client = TcpClient::new(*addr, Duration::from_millis(300), bind_addr);
 
                 let conns = conns.clone();


### PR DESCRIPTION
Bind client socket to address. used for listen socket (raft.this-node in bioyino). So no external API changed in raft-tokio, only some internal methods.